### PR TITLE
fix: only load dotenv in explicit development mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-// Load .env file in development mode
-if (process.env.NODE_ENV !== 'production') {
+// Load .env file only in explicit development mode
+if (process.env.NODE_ENV === 'development') {
   try {
     const { config } = await import('dotenv');
     const result = config();

--- a/tests/unit/dotenv-loading.test.ts
+++ b/tests/unit/dotenv-loading.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import path from 'node:path';
+
+const execFileAsync = promisify(execFile);
+
+const INDEX_PATH = path.resolve(__dirname, '../../src/index.ts');
+
+/**
+ * Spawns the server entry point with tsx and captures stderr.
+ * Sends a short timeout to avoid hanging (the server listens on stdin).
+ */
+async function getStderrWithEnv(nodeEnv: string | undefined): Promise<string> {
+  const env: Record<string, string> = {
+    ...process.env as Record<string, string>,
+    PATH: process.env.PATH || '',
+  };
+
+  if (nodeEnv !== undefined) {
+    env.NODE_ENV = nodeEnv;
+  } else {
+    delete env.NODE_ENV;
+  }
+
+  // We don't need GOOGLE_APPLICATION_CREDENTIALS for this test —
+  // we just need to see whether dotenv loading produces stderr output
+  // before the server errors out on missing credentials.
+  delete env.GOOGLE_APPLICATION_CREDENTIALS;
+
+  try {
+    const { stderr } = await execFileAsync(
+      'npx',
+      ['tsx', INDEX_PATH],
+      {
+        env,
+        timeout: 3000,
+        // Close stdin immediately so the process exits
+        // (StdioServerTransport will error when stdin closes)
+      },
+    );
+    return stderr;
+  } catch (error: any) {
+    // The process will exit with an error (missing credentials or stdin close),
+    // but we only care about stderr content before that happens.
+    return error.stderr || '';
+  }
+}
+
+describe('dotenv loading', () => {
+  it('should NOT attempt to load dotenv when NODE_ENV is unset', async () => {
+    const stderr = await getStderrWithEnv(undefined);
+    expect(stderr).not.toContain('Failed to load .env file');
+    expect(stderr).not.toContain('Loaded .env file');
+  }, 10000);
+
+  it('should NOT attempt to load dotenv when NODE_ENV is "production"', async () => {
+    const stderr = await getStderrWithEnv('production');
+    expect(stderr).not.toContain('Failed to load .env file');
+    expect(stderr).not.toContain('Loaded .env file');
+  }, 10000);
+
+  it('should NOT attempt to load dotenv when NODE_ENV is "test"', async () => {
+    const stderr = await getStderrWithEnv('test');
+    expect(stderr).not.toContain('Failed to load .env file');
+    expect(stderr).not.toContain('Loaded .env file');
+  }, 10000);
+
+  it('should attempt to load dotenv when NODE_ENV is "development"', async () => {
+    const stderr = await getStderrWithEnv('development');
+    // In development mode, dotenv should be attempted.
+    // It will either succeed ("Loaded .env file") or fail ("Failed to load .env file").
+    // Either way, it should have tried.
+    const triedDotenv =
+      stderr.includes('Loaded .env file') ||
+      stderr.includes('Failed to load .env file');
+    expect(triedDotenv).toBe(true);
+  }, 10000);
+});


### PR DESCRIPTION
## Summary

- The dotenv import guard used `NODE_ENV !== 'production'`, which caused dotenv to load in any non-production environment — including when running as an MCP stdio server where `NODE_ENV` is typically unset
- In the bundled ESM output, the dynamic `import('dotenv')` produced stderr warnings (e.g., `require` not supported in ESM) that interfered with JSON-RPC communication over stdio, causing MCP clients like Claude Code to fail to connect
- Changed the condition to `NODE_ENV === 'development'` so dotenv only loads when explicitly opted in

## Test plan

- [x] Added `tests/unit/dotenv-loading.test.ts` with 4 cases covering `NODE_ENV` unset, `production`, `test`, and `development`
- [x] Tests verified RED against the original code (2 failures), GREEN after the fix
- [x] Full test suite passes (223 tests, 0 failures)
- [x] Confirmed fix resolves MCP stdio connection failures in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)