### PR TITLE
Fix nested array items in tool schemas

### DIFF
--- a/src/tools/append-values.ts
+++ b/src/tools/append-values.ts
@@ -25,6 +25,7 @@ export const appendValuesTool: Tool = {
         type: 'array',
         items: {
           type: 'array',
+          items: {},
         },
         description: 'A 2D array of values to append, where each inner array represents a row',
       },

--- a/src/tools/batch-update-values.ts
+++ b/src/tools/batch-update-values.ts
@@ -27,6 +27,7 @@ export const batchUpdateValuesTool: Tool = {
               type: 'array',
               items: {
                 type: 'array',
+                items: {},
               },
               description: 'A 2D array of values for this range',
             },

--- a/src/tools/insert-rows.ts
+++ b/src/tools/insert-rows.ts
@@ -36,6 +36,7 @@ export const insertRowsTool: Tool = {
         type: 'array',
         items: {
           type: 'array',
+          items: {},
         },
         description: 'Optional 2D array of values to fill the newly inserted rows',
       },

--- a/src/tools/update-values.ts
+++ b/src/tools/update-values.ts
@@ -31,6 +31,7 @@ export const updateValuesTool: Tool = {
         type: 'array',
         items: {
           type: 'array',
+          items: {},
         },
         description: 'A 2D array of values to update, where each inner array represents a row',
       },

--- a/tests/unit/tools/input-schemas.test.ts
+++ b/tests/unit/tools/input-schemas.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { appendValuesTool } from '../../../src/tools/append-values';
+import { updateValuesTool } from '../../../src/tools/update-values';
+import { batchUpdateValuesTool } from '../../../src/tools/batch-update-values';
+import { insertRowsTool } from '../../../src/tools/insert-rows';
+
+describe('tool input schemas', () => {
+  it('defines items for nested 2D values arrays', () => {
+    expect(appendValuesTool.inputSchema.properties?.values).toMatchObject({
+      type: 'array',
+      items: {
+        type: 'array',
+        items: {},
+      },
+    });
+
+    expect(updateValuesTool.inputSchema.properties?.values).toMatchObject({
+      type: 'array',
+      items: {
+        type: 'array',
+        items: {},
+      },
+    });
+
+    expect(batchUpdateValuesTool.inputSchema.properties?.data).toMatchObject({
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          values: {
+            type: 'array',
+            items: {
+              type: 'array',
+              items: {},
+            },
+          },
+        },
+      },
+    });
+
+    expect(insertRowsTool.inputSchema.properties?.values).toMatchObject({
+      type: 'array',
+      items: {
+        type: 'array',
+        items: {},
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- fix invalid nested array schemas for 2D `values` inputs
- cover all affected tools, not just `sheets_append_values`
- add a regression test to ensure nested arrays always declare `items`

Closes #122.

## What changed
This updates the input schemas for:
- `sheets_append_values`
- `sheets_update_values`
- `sheets_batch_update_values`
- `sheets_insert_rows`

Each nested `array` under `values.items` now also defines `items`, which makes the generated JSON Schema acceptable to MCP clients that validate array schemas strictly.

## Validation
- `npm run test:run` ✅
- `npm run build` ✅

## Notes
I also tried `npm run check`, but it currently fails on pre-existing repository-wide Prettier line-ending issues (`Delete ␍`) unrelated to this change.