### PR TITLE
Add dedicated row and column deletion tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ npm run dev  # Watch mode with auto-reload
 | `sheets_clear_values` | Clear all values in a range (preserves formatting) | `spreadsheetId`, `range` |
 | `sheets_insert_rows` | Insert blank or pre-filled rows at a specific position | `spreadsheetId`, `range` (anchor), `rows`, `position` (BEFORE/AFTER), `values` |
 | `sheets_delete_columns` | Delete one or more columns using a full-column A1 range | `spreadsheetId`, `range` (e.g. `Sheet1!B:D`) |
+| `sheets_delete_rows` | Delete one or more rows using a full-row A1 range | `spreadsheetId`, `range` (e.g. `Sheet1!2:4`) |
 | `sheets_insert_link` | Insert a hyperlink formula into a cell | `spreadsheetId`, `range`, `url`, `label` |
 | `sheets_insert_date` | Insert a date/datetime value formatted correctly into a cell | `spreadsheetId`, `range`, `date`, `format` |
 
@@ -559,6 +560,30 @@ Delete one or more columns from a sheet using a full-column A1 range.
 {
   "spreadsheetId": "your-spreadsheet-id",
   "range": "C:C"
+}
+```
+
+### sheets_delete_rows
+
+Delete one or more rows from a sheet using a full-row A1 range.
+
+**Parameters:**
+- `spreadsheetId` (required): The ID of the spreadsheet
+- `range` (required): Full-row A1 range to delete (e.g., "Sheet1!2:4" or "Sheet1!3:3")
+
+**Examples:**
+
+```javascript
+// Delete rows 2 through 4 from Sheet1
+{
+  "spreadsheetId": "your-spreadsheet-id",
+  "range": "Sheet1!2:4"
+}
+
+// Delete a single row from the first sheet
+{
+  "spreadsheetId": "your-spreadsheet-id",
+  "range": "3:3"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ npm run dev  # Watch mode with auto-reload
 | `sheets_append_values` | Append rows after the last row of an existing table. **Default `insertDataOption` is `OVERWRITE`** — set `INSERT_ROWS` to push existing rows down | `spreadsheetId`, `range`, `values`, `valueInputOption`, `insertDataOption` |
 | `sheets_clear_values` | Clear all values in a range (preserves formatting) | `spreadsheetId`, `range` |
 | `sheets_insert_rows` | Insert blank or pre-filled rows at a specific position | `spreadsheetId`, `range` (anchor), `rows`, `position` (BEFORE/AFTER), `values` |
+| `sheets_delete_columns` | Delete one or more columns using a full-column A1 range | `spreadsheetId`, `range` (e.g. `Sheet1!B:D`) |
 | `sheets_insert_link` | Insert a hyperlink formula into a cell | `spreadsheetId`, `range`, `url`, `label` |
 | `sheets_insert_date` | Insert a date/datetime value formatted correctly into a cell | `spreadsheetId`, `range`, `date`, `format` |
 
@@ -534,6 +535,30 @@ Insert new rows at a specific position in a spreadsheet with optional data.
     ["Jane", "Smith", "jane@example.com"],
     ["Bob", "Johnson", "bob@example.com"]
   ]
+}
+```
+
+### sheets_delete_columns
+
+Delete one or more columns from a sheet using a full-column A1 range.
+
+**Parameters:**
+- `spreadsheetId` (required): The ID of the spreadsheet
+- `range` (required): Full-column A1 range to delete (e.g., "Sheet1!B:D" or "Sheet1!C:C")
+
+**Examples:**
+
+```javascript
+// Delete columns B through D from Sheet1
+{
+  "spreadsheetId": "your-spreadsheet-id",
+  "range": "Sheet1!B:D"
+}
+
+// Delete a single column from the first sheet
+{
+  "spreadsheetId": "your-spreadsheet-id",
+  "range": "C:C"
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,7 @@ const toolHandlers = new Map<string, (input: any) => Promise<any>>([
   ['sheets_insert_date', tools.handleInsertDate],
   // Row operations
   ['sheets_insert_rows', tools.handleInsertRows],
+  ['sheets_delete_columns', tools.handleDeleteColumns],
   // READ / Snapshot tools
   ['sheets_get_merged_cells', tools.handleGetMergedCells],
   ['sheets_get_sheet_dimensions', tools.handleGetSheetDimensions],
@@ -117,6 +118,7 @@ const allTools = [
   tools.insertDateTool,
   // Row operations
   tools.insertRowsTool,
+  tools.deleteColumnsTool,
   // READ / Snapshot tools
   tools.getMergedCellsTool,
   tools.getSheetDimensionsTool,

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ const toolHandlers = new Map<string, (input: any) => Promise<any>>([
   // Row operations
   ['sheets_insert_rows', tools.handleInsertRows],
   ['sheets_delete_columns', tools.handleDeleteColumns],
+  ['sheets_delete_rows', tools.handleDeleteRows],
   // READ / Snapshot tools
   ['sheets_get_merged_cells', tools.handleGetMergedCells],
   ['sheets_get_sheet_dimensions', tools.handleGetSheetDimensions],
@@ -119,6 +120,7 @@ const allTools = [
   // Row operations
   tools.insertRowsTool,
   tools.deleteColumnsTool,
+  tools.deleteRowsTool,
   // READ / Snapshot tools
   tools.getMergedCellsTool,
   tools.getSheetDimensionsTool,

--- a/src/tools/delete-columns.ts
+++ b/src/tools/delete-columns.ts
@@ -1,0 +1,83 @@
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { getAuthenticatedClient } from '../utils/google-auth.js';
+import { handleError } from '../utils/error-handler.js';
+import { validateDeleteColumnsInput } from '../utils/validators.js';
+import { formatToolResponse } from '../utils/formatters.js';
+import { columnToIndex, extractSheetName, getSheetId } from '../utils/range-helpers.js';
+
+export const deleteColumnsTool: Tool = {
+  name: 'sheets_delete_columns',
+  description: 'Delete one or more columns from a Google Sheet using a full-column A1 range',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      spreadsheetId: {
+        type: 'string',
+        description: 'The ID of the spreadsheet (found in the URL after /d/)',
+      },
+      range: {
+        type: 'string',
+        description:
+          'Full-column A1 range to delete (e.g., "Sheet1!B:D" or "Sheet1!C:C"). If sheet name is omitted, the first sheet is used',
+      },
+    },
+    required: ['spreadsheetId', 'range'],
+  },
+};
+
+function parseColumnRange(range: string): { startIndex: number; endIndex: number } {
+  const match = range.match(/^([A-Z]+):([A-Z]+)$/i);
+  if (!match?.[1] || !match[2]) {
+    throw new Error('Column range must use full-column A1 notation, e.g. "B:D" or "C:C"');
+  }
+
+  const startIndex = columnToIndex(match[1].toUpperCase());
+  const endIndex = columnToIndex(match[2].toUpperCase()) + 1;
+
+  if (endIndex <= startIndex) {
+    throw new Error('Column range end must be greater than or equal to the start column');
+  }
+
+  return { startIndex, endIndex };
+}
+
+export async function handleDeleteColumns(input: any) {
+  try {
+    const validatedInput = validateDeleteColumnsInput(input);
+    const sheets = await getAuthenticatedClient();
+
+    const { sheetName, range } = extractSheetName(validatedInput.range);
+    const sheetId = await getSheetId(sheets, validatedInput.spreadsheetId, sheetName);
+    const { startIndex, endIndex } = parseColumnRange(range);
+
+    await sheets.spreadsheets.batchUpdate({
+      spreadsheetId: validatedInput.spreadsheetId,
+      requestBody: {
+        requests: [
+          {
+            deleteDimension: {
+              range: {
+                sheetId,
+                dimension: 'COLUMNS',
+                startIndex,
+                endIndex,
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    return formatToolResponse(
+      `Successfully deleted ${endIndex - startIndex} columns in range ${validatedInput.range}`,
+      {
+        spreadsheetId: validatedInput.spreadsheetId,
+        sheetId,
+        deletedColumns: endIndex - startIndex,
+        range: validatedInput.range,
+      }
+    );
+  } catch (error) {
+    return handleError(error);
+  }
+}

--- a/src/tools/delete-rows.ts
+++ b/src/tools/delete-rows.ts
@@ -1,0 +1,90 @@
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { getAuthenticatedClient } from '../utils/google-auth.js';
+import { handleError } from '../utils/error-handler.js';
+import { validateDeleteRowsInput } from '../utils/validators.js';
+import { formatToolResponse } from '../utils/formatters.js';
+import { extractSheetName, getSheetId } from '../utils/range-helpers.js';
+
+export const deleteRowsTool: Tool = {
+  name: 'sheets_delete_rows',
+  description: 'Delete one or more rows from a Google Sheet using a full-row A1 range',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      spreadsheetId: {
+        type: 'string',
+        description: 'The ID of the spreadsheet (found in the URL after /d/)',
+      },
+      range: {
+        type: 'string',
+        description:
+          'Full-row A1 range to delete (e.g., "Sheet1!2:4" or "Sheet1!3:3"). If sheet name is omitted, the first sheet is used',
+      },
+    },
+    required: ['spreadsheetId', 'range'],
+  },
+};
+
+function parseRowRange(range: string): { startIndex: number; endIndex: number } {
+  const match = range.match(/^(\d+):(\d+)$/);
+  if (!match?.[1] || !match[2]) {
+    throw new Error('Row range must use full-row A1 notation, e.g. "2:4" or "3:3"');
+  }
+
+  const startRow = parseInt(match[1], 10);
+  const endRow = parseInt(match[2], 10);
+
+  if (Number.isNaN(startRow) || Number.isNaN(endRow) || startRow <= 0 || endRow <= 0) {
+    throw new Error('Row numbers must be positive integers');
+  }
+
+  if (endRow < startRow) {
+    throw new Error('Row range end must be greater than or equal to the start row');
+  }
+
+  return {
+    startIndex: startRow - 1,
+    endIndex: endRow,
+  };
+}
+
+export async function handleDeleteRows(input: any) {
+  try {
+    const validatedInput = validateDeleteRowsInput(input);
+    const sheets = await getAuthenticatedClient();
+
+    const { sheetName, range } = extractSheetName(validatedInput.range);
+    const sheetId = await getSheetId(sheets, validatedInput.spreadsheetId, sheetName);
+    const { startIndex, endIndex } = parseRowRange(range);
+
+    await sheets.spreadsheets.batchUpdate({
+      spreadsheetId: validatedInput.spreadsheetId,
+      requestBody: {
+        requests: [
+          {
+            deleteDimension: {
+              range: {
+                sheetId,
+                dimension: 'ROWS',
+                startIndex,
+                endIndex,
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    return formatToolResponse(
+      `Successfully deleted ${endIndex - startIndex} rows in range ${validatedInput.range}`,
+      {
+        spreadsheetId: validatedInput.spreadsheetId,
+        sheetId,
+        deletedRows: endIndex - startIndex,
+        range: validatedInput.range,
+      }
+    );
+  } catch (error) {
+    return handleError(error);
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -33,6 +33,7 @@ export * from './insert-date.js';
 
 // Row operations
 export * from './insert-rows.js';
+export * from './delete-columns.js';
 
 // READ / Snapshot tools
 export * from './get-merged-cells.js';

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -34,6 +34,7 @@ export * from './insert-date.js';
 // Row operations
 export * from './insert-rows.js';
 export * from './delete-columns.js';
+export * from './delete-rows.js';
 
 // READ / Snapshot tools
 export * from './get-merged-cells.js';

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -218,6 +218,11 @@ export interface BatchFormatCellsInput {
   }>;
 }
 
+export interface DeleteColumnsInput {
+  spreadsheetId: string;
+  range: string;
+}
+
 // Chart types
 export type ChartType =
   | 'COLUMN'

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -223,6 +223,11 @@ export interface DeleteColumnsInput {
   range: string;
 }
 
+export interface DeleteRowsInput {
+  spreadsheetId: string;
+  range: string;
+}
+
 // Chart types
 export type ChartType =
   | 'COLUMN'

--- a/src/utils/error-messages.ts
+++ b/src/utils/error-messages.ts
@@ -9,6 +9,8 @@ export const ERROR_MESSAGES = {
 
   // Range errors
   INVALID_RANGE: 'Invalid range format. Use A1 notation (e.g., "Sheet1!A1:B10")',
+  INVALID_COLUMN_RANGE:
+    'Invalid column range format. Use a full-column A1 range (e.g., "Sheet1!B:D" or "Sheet1!C:C")',
   RANGE_REQUIRED: 'range is required and must be a string',
 
   // Spreadsheet errors

--- a/src/utils/error-messages.ts
+++ b/src/utils/error-messages.ts
@@ -11,6 +11,8 @@ export const ERROR_MESSAGES = {
   INVALID_RANGE: 'Invalid range format. Use A1 notation (e.g., "Sheet1!A1:B10")',
   INVALID_COLUMN_RANGE:
     'Invalid column range format. Use a full-column A1 range (e.g., "Sheet1!B:D" or "Sheet1!C:C")',
+  INVALID_ROW_RANGE:
+    'Invalid row range format. Use a full-row A1 range (e.g., "Sheet1!2:4" or "Sheet1!3:3")',
   RANGE_REQUIRED: 'range is required and must be a string',
 
   // Spreadsheet errors

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -23,6 +23,7 @@ import {
   DeleteChartInput,
   ChartType,
   DeleteColumnsInput,
+  DeleteRowsInput,
 } from '../types/tools.js';
 import { ERROR_MESSAGES } from './error-messages.js';
 import {
@@ -542,6 +543,21 @@ export function validateDeleteColumnsInput(input: any): DeleteColumnsInput {
   const { range } = extractSheetName(input.range);
   if (!/^[A-Z]+:[A-Z]+$/i.test(range)) {
     throw new Error(ERROR_MESSAGES.INVALID_COLUMN_RANGE);
+  }
+
+  return {
+    spreadsheetId: input.spreadsheetId,
+    range: input.range,
+  };
+}
+
+export function validateDeleteRowsInput(input: any): DeleteRowsInput {
+  validateSpreadsheetIdField(input.spreadsheetId);
+  validateRangeField(input.range);
+
+  const { range } = extractSheetName(input.range);
+  if (!/^\d+:\d+$/.test(range)) {
+    throw new Error(ERROR_MESSAGES.INVALID_ROW_RANGE);
   }
 
   return {

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -22,6 +22,7 @@ import {
   UpdateChartInput,
   DeleteChartInput,
   ChartType,
+  DeleteColumnsInput,
 } from '../types/tools.js';
 import { ERROR_MESSAGES } from './error-messages.js';
 import {
@@ -29,6 +30,7 @@ import {
   createSheetValidator,
   COMMON_DEFAULTS,
 } from './validation-helpers.js';
+import { extractSheetName } from './range-helpers.js';
 
 // Helper validation functions to eliminate duplication
 function validateRequiredString(value: any, fieldName: string): void {
@@ -530,5 +532,20 @@ export function validateInsertRowsInput(input: any): any {
     inheritFromBefore,
     values: input.values,
     valueInputOption,
+  };
+}
+
+export function validateDeleteColumnsInput(input: any): DeleteColumnsInput {
+  validateSpreadsheetIdField(input.spreadsheetId);
+  validateRangeField(input.range);
+
+  const { range } = extractSheetName(input.range);
+  if (!/^[A-Z]+:[A-Z]+$/i.test(range)) {
+    throw new Error(ERROR_MESSAGES.INVALID_COLUMN_RANGE);
+  }
+
+  return {
+    spreadsheetId: input.spreadsheetId,
+    range: input.range,
   };
 }

--- a/tests/unit/tools/delete-columns.test.ts
+++ b/tests/unit/tools/delete-columns.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleDeleteColumns } from '../../../src/tools/delete-columns.js';
+import * as googleAuth from '../../../src/utils/google-auth.js';
+import * as errorHandler from '../../../src/utils/error-handler.js';
+import * as rangeHelpers from '../../../src/utils/range-helpers.js';
+
+vi.mock('../../../src/utils/google-auth.js');
+vi.mock('../../../src/utils/error-handler.js');
+vi.mock('../../../src/utils/range-helpers.js');
+
+describe('handleDeleteColumns', () => {
+  const mockSheets = {
+    spreadsheets: {
+      batchUpdate: vi.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(googleAuth.getAuthenticatedClient).mockResolvedValue(mockSheets as any);
+    vi.mocked(rangeHelpers.extractSheetName).mockReturnValue({
+      sheetName: 'Sheet1',
+      range: 'B:D',
+    });
+    vi.mocked(rangeHelpers.getSheetId).mockResolvedValue(0);
+    vi.mocked(rangeHelpers.columnToIndex).mockImplementation((column: string) => {
+      const map: Record<string, number> = { B: 1, C: 2, D: 3 };
+      return map[column] ?? 0;
+    });
+  });
+
+  it('should delete columns using a deleteDimension request', async () => {
+    mockSheets.spreadsheets.batchUpdate.mockResolvedValue({ data: {} });
+
+    const result = await handleDeleteColumns({
+      spreadsheetId: 'test-id',
+      range: 'Sheet1!B:D',
+    });
+
+    expect(mockSheets.spreadsheets.batchUpdate).toHaveBeenCalledWith({
+      spreadsheetId: 'test-id',
+      requestBody: {
+        requests: [
+          {
+            deleteDimension: {
+              range: {
+                sheetId: 0,
+                dimension: 'COLUMNS',
+                startIndex: 1,
+                endIndex: 4,
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(result).toMatchObject({
+      content: [
+        expect.objectContaining({
+          text: expect.stringContaining('Successfully deleted 3 columns'),
+        }),
+      ],
+    });
+  });
+
+  it('should fall back to the first sheet when no sheet name is provided', async () => {
+    vi.mocked(rangeHelpers.extractSheetName).mockReturnValue({
+      range: 'C:C',
+    });
+    vi.mocked(rangeHelpers.columnToIndex).mockImplementation((column: string) =>
+      column === 'C' ? 2 : 0
+    );
+    mockSheets.spreadsheets.batchUpdate.mockResolvedValue({ data: {} });
+
+    await handleDeleteColumns({
+      spreadsheetId: 'test-id',
+      range: 'C:C',
+    });
+
+    expect(rangeHelpers.getSheetId).toHaveBeenCalledWith(mockSheets as any, 'test-id', undefined);
+    expect(mockSheets.spreadsheets.batchUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestBody: {
+          requests: [
+            {
+              deleteDimension: {
+                range: {
+                  sheetId: 0,
+                  dimension: 'COLUMNS',
+                  startIndex: 2,
+                  endIndex: 3,
+                },
+              },
+            },
+          ],
+        },
+      })
+    );
+  });
+
+  it('should handle API errors', async () => {
+    const error = new Error('API Error');
+    mockSheets.spreadsheets.batchUpdate.mockRejectedValue(error);
+    vi.mocked(errorHandler.handleError).mockReturnValue({
+      content: [{ type: 'text', text: 'Error occurred' }],
+    } as any);
+
+    const result = await handleDeleteColumns({
+      spreadsheetId: 'test-id',
+      range: 'Sheet1!B:D',
+    });
+
+    expect(errorHandler.handleError).toHaveBeenCalledWith(error);
+    expect(result).toMatchObject({
+      content: [{ type: 'text', text: 'Error occurred' }],
+    });
+  });
+});

--- a/tests/unit/tools/delete-rows.test.ts
+++ b/tests/unit/tools/delete-rows.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleDeleteRows } from '../../../src/tools/delete-rows.js';
+import * as googleAuth from '../../../src/utils/google-auth.js';
+import * as errorHandler from '../../../src/utils/error-handler.js';
+import * as rangeHelpers from '../../../src/utils/range-helpers.js';
+
+vi.mock('../../../src/utils/google-auth.js');
+vi.mock('../../../src/utils/error-handler.js');
+vi.mock('../../../src/utils/range-helpers.js');
+
+describe('handleDeleteRows', () => {
+  const mockSheets = {
+    spreadsheets: {
+      batchUpdate: vi.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(googleAuth.getAuthenticatedClient).mockResolvedValue(mockSheets as any);
+    vi.mocked(rangeHelpers.extractSheetName).mockReturnValue({
+      sheetName: 'Sheet1',
+      range: '2:4',
+    });
+    vi.mocked(rangeHelpers.getSheetId).mockResolvedValue(0);
+  });
+
+  it('should delete rows using a deleteDimension request', async () => {
+    mockSheets.spreadsheets.batchUpdate.mockResolvedValue({ data: {} });
+
+    const result = await handleDeleteRows({
+      spreadsheetId: 'test-id',
+      range: 'Sheet1!2:4',
+    });
+
+    expect(mockSheets.spreadsheets.batchUpdate).toHaveBeenCalledWith({
+      spreadsheetId: 'test-id',
+      requestBody: {
+        requests: [
+          {
+            deleteDimension: {
+              range: {
+                sheetId: 0,
+                dimension: 'ROWS',
+                startIndex: 1,
+                endIndex: 4,
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(result).toMatchObject({
+      content: [
+        expect.objectContaining({
+          text: expect.stringContaining('Successfully deleted 3 rows'),
+        }),
+      ],
+    });
+  });
+
+  it('should fall back to the first sheet when no sheet name is provided', async () => {
+    vi.mocked(rangeHelpers.extractSheetName).mockReturnValue({
+      range: '3:3',
+    });
+    mockSheets.spreadsheets.batchUpdate.mockResolvedValue({ data: {} });
+
+    await handleDeleteRows({
+      spreadsheetId: 'test-id',
+      range: '3:3',
+    });
+
+    expect(rangeHelpers.getSheetId).toHaveBeenCalledWith(mockSheets as any, 'test-id', undefined);
+    expect(mockSheets.spreadsheets.batchUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestBody: {
+          requests: [
+            {
+              deleteDimension: {
+                range: {
+                  sheetId: 0,
+                  dimension: 'ROWS',
+                  startIndex: 2,
+                  endIndex: 3,
+                },
+              },
+            },
+          ],
+        },
+      })
+    );
+  });
+
+  it('should handle API errors', async () => {
+    const error = new Error('API Error');
+    mockSheets.spreadsheets.batchUpdate.mockRejectedValue(error);
+    vi.mocked(errorHandler.handleError).mockReturnValue({
+      content: [{ type: 'text', text: 'Error occurred' }],
+    } as any);
+
+    const result = await handleDeleteRows({
+      spreadsheetId: 'test-id',
+      range: 'Sheet1!2:4',
+    });
+
+    expect(errorHandler.handleError).toHaveBeenCalledWith(error);
+    expect(result).toMatchObject({
+      content: [{ type: 'text', text: 'Error occurred' }],
+    });
+  });
+});

--- a/tests/unit/tools/input-schemas.test.ts
+++ b/tests/unit/tools/input-schemas.test.ts
@@ -4,6 +4,7 @@ import { updateValuesTool } from '../../../src/tools/update-values';
 import { batchUpdateValuesTool } from '../../../src/tools/batch-update-values';
 import { insertRowsTool } from '../../../src/tools/insert-rows';
 import { deleteColumnsTool } from '../../../src/tools/delete-columns';
+import { deleteRowsTool } from '../../../src/tools/delete-rows';
 
 describe('tool input schemas', () => {
   it('defines items for nested 2D values arrays', () => {
@@ -48,6 +49,10 @@ describe('tool input schemas', () => {
     });
 
     expect(deleteColumnsTool.inputSchema.properties?.range).toMatchObject({
+      type: 'string',
+    });
+
+    expect(deleteRowsTool.inputSchema.properties?.range).toMatchObject({
       type: 'string',
     });
   });

--- a/tests/unit/tools/input-schemas.test.ts
+++ b/tests/unit/tools/input-schemas.test.ts
@@ -3,6 +3,7 @@ import { appendValuesTool } from '../../../src/tools/append-values';
 import { updateValuesTool } from '../../../src/tools/update-values';
 import { batchUpdateValuesTool } from '../../../src/tools/batch-update-values';
 import { insertRowsTool } from '../../../src/tools/insert-rows';
+import { deleteColumnsTool } from '../../../src/tools/delete-columns';
 
 describe('tool input schemas', () => {
   it('defines items for nested 2D values arrays', () => {
@@ -44,6 +45,10 @@ describe('tool input schemas', () => {
         type: 'array',
         items: {},
       },
+    });
+
+    expect(deleteColumnsTool.inputSchema.properties?.range).toMatchObject({
+      type: 'string',
     });
   });
 });

--- a/tests/unit/utils/validators.test.ts
+++ b/tests/unit/utils/validators.test.ts
@@ -20,6 +20,7 @@ import {
   validateUnmergeCellsInput,
   validateAddConditionalFormattingInput,
   validateInsertRowsInput,
+  validateDeleteColumnsInput,
 } from '../../../src/utils/validators';
 import { testSpreadsheetIds, testRanges, testValues, testInputs, testErrors } from '../../fixtures/test-data';
 
@@ -246,6 +247,29 @@ describe('validateClearValuesInput', () => {
   it('should throw error for missing fields', () => {
     expect(() => validateClearValuesInput({})).toThrow('spreadsheetId is required');
     expect(() => validateClearValuesInput({ spreadsheetId: 'test' })).toThrow('range is required');
+  });
+});
+
+describe('validateDeleteColumnsInput', () => {
+  it('should accept full-column ranges', () => {
+    const result = validateDeleteColumnsInput({
+      spreadsheetId: '1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms',
+      range: 'Sheet1!B:D',
+    });
+
+    expect(result).toEqual({
+      spreadsheetId: '1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms',
+      range: 'Sheet1!B:D',
+    });
+  });
+
+  it('should reject non-column ranges', () => {
+    expect(() =>
+      validateDeleteColumnsInput({
+        spreadsheetId: '1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms',
+        range: 'Sheet1!B2:D4',
+      })
+    ).toThrow('Invalid column range format');
   });
 });
 

--- a/tests/unit/utils/validators.test.ts
+++ b/tests/unit/utils/validators.test.ts
@@ -21,6 +21,7 @@ import {
   validateAddConditionalFormattingInput,
   validateInsertRowsInput,
   validateDeleteColumnsInput,
+  validateDeleteRowsInput,
 } from '../../../src/utils/validators';
 import { testSpreadsheetIds, testRanges, testValues, testInputs, testErrors } from '../../fixtures/test-data';
 
@@ -270,6 +271,29 @@ describe('validateDeleteColumnsInput', () => {
         range: 'Sheet1!B2:D4',
       })
     ).toThrow('Invalid column range format');
+  });
+});
+
+describe('validateDeleteRowsInput', () => {
+  it('should accept full-row ranges', () => {
+    const result = validateDeleteRowsInput({
+      spreadsheetId: '1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms',
+      range: 'Sheet1!2:4',
+    });
+
+    expect(result).toEqual({
+      spreadsheetId: '1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms',
+      range: 'Sheet1!2:4',
+    });
+  });
+
+  it('should reject non-row ranges', () => {
+    expect(() =>
+      validateDeleteRowsInput({
+        spreadsheetId: '1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms',
+        range: 'Sheet1!B2:D4',
+      })
+    ).toThrow('Invalid row range format');
   });
 });
 


### PR DESCRIPTION
## Summary

This PR adds two dedicated MCP tools for structural row/column deletion in Google Sheets:

- `sheets_delete_columns` for full-column A1 ranges such as `Sheet1!B:D` or `C:C`
- `sheets_delete_rows` for full-row A1 ranges such as `Sheet1!2:4` or `3:3`

Both tools follow the project's existing conventions for naming, validation, registration, and response formatting, and they are implemented as first-class tools instead of requiring lower-level batch update requests.

## What changed

- added `src/tools/delete-columns.ts`
- added `src/tools/delete-rows.ts`
- registered both tools in `src/index.ts` and exported them from `src/tools/index.ts`
- added typed inputs in `src/types/tools.ts`
- added dedicated validation and error messages for full-column and full-row A1 ranges
- documented both tools in the README, including examples
- added focused unit tests for handlers, validators, and input schemas

## Why

The server already supported row insertion, but it did not expose parallel delete operations for rows or columns. These additions make common sheet-structure edits available directly through the MCP surface and remove the need for downstream clients to emulate them through custom Sheets API requests.

## Validation

I verified the implementation locally with:

- `npm test -- --run tests/unit/tools/delete-rows.test.ts tests/unit/tools/delete-columns.test.ts tests/unit/utils/validators.test.ts tests/unit/tools/input-schemas.test.ts`
- `npm run build`
- `npm run check`

I also exercised both tools through the local MCP server against a real test spreadsheet:

- confirmed `sheets_delete_columns` deletes single and multi-column ranges
- confirmed `sheets_delete_rows` deletes single and multi-row ranges
