### PR TITLE
feat: publish to MCP Registry on release (v1.8.1)

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,59 @@
+name: Publish to MCP Registry
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Sync server.json version with release tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if [ -z "$VERSION" ] || [ "$VERSION" = "$GITHUB_REF_NAME" ]; then
+            VERSION=$(node -p "require('./package.json').version")
+          fi
+          echo "Publishing version: $VERSION"
+          node -e "
+            const fs = require('fs');
+            const s = JSON.parse(fs.readFileSync('server.json', 'utf8'));
+            s.version = '$VERSION';
+            for (const p of s.packages || []) p.version = '$VERSION';
+            fs.writeFileSync('server.json', JSON.stringify(s, null, 2) + '\n');
+          "
+          cat server.json
+
+      - name: Wait for npm package to be available
+        run: |
+          VERSION=$(node -p "require('./server.json').version")
+          echo "Waiting for mcp-gsheets@$VERSION on npm..."
+          for i in $(seq 1 60); do
+            if npm view "mcp-gsheets@$VERSION" version 2>/dev/null | grep -q "^$VERSION$"; then
+              echo "Package available."
+              exit 0
+            fi
+            echo "Not yet (attempt $i/60), sleeping 10s..."
+            sleep 10
+          done
+          echo "Timed out waiting for npm package."
+          exit 1
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+          chmod +x mcp-publisher
+
+      - name: Login to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- mcp-name: io.github.freema/mcp-gsheets -->
+
 # MCP Google Sheets Server
 
 <a href="https://glama.ai/mcp/servers/@freema/mcp-gsheets">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-gsheets",
-  "version": "1.7.1",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-gsheets",
-      "version": "1.7.1",
+      "version": "1.8.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mcp-gsheets",
-  "version": "1.8.0",
+  "version": "1.8.1",
+  "mcpName": "io.github.freema/mcp-gsheets",
   "description": "Model Context Protocol (MCP) server for Google Sheets API integration",
   "author": "freema",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "name": "io.github.freema/mcp-gsheets",
+  "description": "MCP server for Google Sheets API — read, write, format, batch operations.",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/freema/mcp-gsheets",
+    "source": "github"
+  },
+  "version": "1.8.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "mcp-gsheets",
+      "version": "1.8.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "GOOGLE_PROJECT_ID",
+          "description": "Google Cloud project ID",
+          "isRequired": true
+        },
+        {
+          "name": "GOOGLE_APPLICATION_CREDENTIALS",
+          "description": "Path to service account key JSON file (auth method 1)",
+          "isRequired": false
+        },
+        {
+          "name": "GOOGLE_SERVICE_ACCOUNT_KEY",
+          "description": "Service account key as JSON string (auth method 2)",
+          "isRequired": false,
+          "isSecret": true
+        },
+        {
+          "name": "GOOGLE_PRIVATE_KEY",
+          "description": "Service account private key in PEM format (auth method 3)",
+          "isRequired": false,
+          "isSecret": true
+        },
+        {
+          "name": "GOOGLE_CLIENT_EMAIL",
+          "description": "Service account email (auth method 3)",
+          "isRequired": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `server.json` at repo root with namespace `io.github.freema/mcp-gsheets` (npm package only — no GHCR/OCI distribution).
- Adds the `<!-- mcp-name: io.github.freema/mcp-gsheets -->` ownership marker to README so `mcp-publisher` can verify the namespace.
- Adds `mcpName` field to `package.json` — required by registry validation when it inspects the published npm package.
- Adds `.github/workflows/publish-mcp-registry.yml` (runs on `release: published` and `workflow_dispatch`). Waits for npm package availability before calling `mcp-publisher publish`. Authenticates via GitHub OIDC — no secrets needed for `io.github.freema/*` namespace.
- Bumps version to `1.8.1` so the next npm publish carries the `mcpName` field (registry rejects packages without it).

## Why now
The official MCP Registry (registry.modelcontextprotocol.io) is the canonical discovery channel for MCP clients (Claude.ai, Cursor, VS Code, Windsurf). Publishing makes the server installable through their built-in catalogs.

## Test plan
- [ ] Merge this PR.
- [ ] Tag and push `v1.8.1` — `release.yml` builds + creates GitHub release, `publish.yml` publishes to npm (already triggers on `tags: 'v*.*.*'`).
- [ ] Once npm `1.8.1` is live, run `gh workflow run publish-mcp-registry.yml --ref main`.
- [ ] Verify entry at https://registry.modelcontextprotocol.io/v0/servers?search=io.github.freema/mcp-gsheets

## Notes
- No Docker/OCI distribution in `server.json` — this repo doesn't push to GHCR. Add later if a Docker image is published.
- GitHub release events created from inside `release.yml` (via `GITHUB_TOKEN`) do **not** trigger downstream workflows. That's why the MCP Registry publish needs to be triggered manually after npm goes live, OR `release.yml` needs to use a PAT instead.