### PR TITLE
fix(ci): actually generate and upload coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,14 @@ jobs:
         run: npm run typecheck
       
       - name: Test
-        run: npm run test:run
-      
+        run: npm run test:coverage
+
       - name: Build
         run: npm run build
-      
+
       - name: Upload coverage
-        if: matrix.node-version == 20 && hashFiles('coverage/lcov.info') != ''
-        uses: codecov/codecov-action@v4
+        if: matrix.node-version == 20
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
     setupFiles: ['./tests/setup.ts'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      // lcov is what Codecov consumes — without it CI has nothing to upload.
+      reporter: ['text', 'json', 'html', 'lcov'],
       exclude: [
         'node_modules/**',
         'dist/**',


### PR DESCRIPTION
The Codecov badge in the README reads **unknown** — `https://codecov.io/gh/freema/mcp-gsheets/branch/main/graph/badge.svg` returns `unknown`, not a percentage. Nothing has ever reached Codecov.

## Why

Two independent breakages, either one sufficient:

1. **CI never collected coverage.** The test step ran `npm run test:run`, which is plain `vitest run`. As a side effect the `thresholds: { branches: 80, functions: 80, lines: 80, statements: 80 }` in `vitest.config.ts` were dead config — nothing ever checked them.
2. **No lcov reporter.** `reporter: ['text', 'json', 'html']` — Codecov consumes `lcov.info`, which was never written. So even `npm run test:coverage` locally produced no uploadable report.

The upload step was guarded by:

```yaml
if: matrix.node-version == 20 && hashFiles('coverage/lcov.info') != ''
```

which evaluated to false every run and skipped the upload silently, without failing the build. That is why this went unnoticed.

## Changes

- CI test step: `npm run test:run` -> `npm run test:coverage`
- `vitest.config.ts`: add `lcov` to the coverage reporters
- Drop the `hashFiles` guard so a genuinely missing report shows up instead of being swallowed. `fail_ci_if_error: false` still means a Codecov outage cannot break CI.
- `codecov/codecov-action@v4` -> `@v7`, matching mcp-jira-stdio

## Coverage was never the problem

Running the fixed command locally:

```
Test Files  31 passed (31)
     Tests  492 passed (492)

Statements   : 95.05% ( 1269/1335 )
Branches     : 85.35% ( 1055/1236 )
Functions    : 98.92% ( 184/186 )
Lines        : 94.91% ( 1233/1299 )
```

All four are comfortably above the 80% thresholds, which this PR makes load-bearing for the first time. `coverage/lcov.info` is now produced and covers 34 source files.