### PR TITLE
feat: add GSHEETS_TOOLSETS and GSHEETS_READ_ONLY to cut context cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,62 @@ cp .env.example .env
 npm run dev  # Watch mode with auto-reload
 ```
 
+## 🎚️ Reducing context cost with toolsets
+
+All 44 tools together cost about **9,900 tokens of context in every session**,
+before the model does anything. Most workflows need a fraction of that.
+`GSHEETS_TOOLSETS` limits which tools the server exposes:
+
+```json
+{
+  "mcpServers": {
+    "gsheets": {
+      "command": "npx",
+      "args": ["mcp-gsheets"],
+      "env": {
+        "GOOGLE_PROJECT_ID": "your-project-id",
+        "GOOGLE_APPLICATION_CREDENTIALS": "/path/to/key.json",
+        "GSHEETS_TOOLSETS": "core,charts"
+      }
+    }
+  }
+}
+```
+
+| Toolset | Tools | What it covers |
+|---|---|---|
+| `core` | 11 | Read/write values, metadata, sheet structure, create spreadsheet |
+| `sheets` | 9 | Sheet lifecycle, rows and columns |
+| `formatting` | 15 | Colours, borders, merges, conditional rules, links, dates |
+| `charts` | 3 | Create, update, delete charts |
+| `tables` | 4 | Native tables |
+| `analysis` | 2 | Full-sheet snapshot, range comparison |
+
+Measured `tools/list` cost:
+
+| Configuration | Tools | ≈ Tokens |
+|---|---|---|
+| _unset_ (default, all toolsets) | 44 | 9,875 |
+| `GSHEETS_TOOLSETS=core` | 11 | 1,986 |
+| `GSHEETS_TOOLSETS=core,sheets` | 20 | 3,548 |
+| `GSHEETS_READ_ONLY=true` | 16 | 3,599 |
+| `GSHEETS_TOOLSETS=core` + read-only | 6 | 912 |
+
+Notes:
+
+- **The default is unchanged** — leave `GSHEETS_TOOLSETS` unset and you get
+  every tool, exactly as before.
+- **`core` is always included.** `GSHEETS_TOOLSETS=charts` means "charts as
+  well as core", not "charts only" — without core the server cannot read a cell.
+- **A typo is a startup error**, not a silently smaller tool list.
+- `GSHEETS_READ_ONLY=true` drops every writing tool and can be combined with
+  `GSHEETS_TOOLSETS`. It is enforced when a tool is called, not just when the
+  list is built, so a client cannot write by naming a hidden tool.
+
+All tools also carry MCP annotations (`readOnlyHint`, `destructiveHint`,
+`idempotentHint`), so clients can skip confirmation prompts on reads and warn
+before destructive operations.
+
 ## 📋 Available Tools
 
 ### Reading Data

--- a/src/config/toolsets.ts
+++ b/src/config/toolsets.ts
@@ -1,0 +1,212 @@
+/**
+ * Toolset filtering.
+ *
+ * All 44 tools together serialise to ~39 KB of `tools/list`, roughly 9,900
+ * tokens of context in every session — before the model has done anything.
+ * Most users need a fraction of that: reading and writing values, maybe sheet
+ * management. `GSHEETS_TOOLSETS` lets them pay only for what they use
+ * (`core` alone is ~2,000).
+ *
+ * Defaults to every toolset, so an existing config keeps working untouched.
+ */
+
+/** Toolset names, in the order they are listed to the user. */
+export const TOOLSET_NAMES = [
+  'core',
+  'sheets',
+  'formatting',
+  'charts',
+  'tables',
+  'analysis',
+] as const;
+
+export type ToolsetName = (typeof TOOLSET_NAMES)[number];
+
+/**
+ * Which tools belong to which toolset. Every tool appears exactly once; the
+ * `toolsets are exhaustive` test keeps this honest against the real registry.
+ */
+export const TOOLSETS: Record<ToolsetName, readonly string[]> = {
+  /** Reading and writing cells, plus the metadata needed to do it safely. */
+  core: [
+    'sheets_check_access',
+    'sheets_get_metadata',
+    'sheets_get_sheet_structure',
+    'sheets_get_sheet_dimensions',
+    'sheets_get_values',
+    'sheets_batch_get_values',
+    'sheets_update_values',
+    'sheets_batch_update_values',
+    'sheets_append_values',
+    'sheets_clear_values',
+    'sheets_create_spreadsheet',
+  ],
+  /** Sheet lifecycle and row/column structure. */
+  sheets: [
+    'sheets_insert_sheet',
+    'sheets_delete_sheet',
+    'sheets_duplicate_sheet',
+    'sheets_copy_to',
+    'sheets_update_sheet_properties',
+    'sheets_batch_delete_sheets',
+    'sheets_insert_rows',
+    'sheets_delete_rows',
+    'sheets_delete_columns',
+  ],
+  /** Cell appearance: colours, borders, merges, conditional rules, links. */
+  formatting: [
+    'sheets_format_cells',
+    'sheets_batch_format_cells',
+    'sheets_update_borders',
+    'sheets_get_border_map',
+    'sheets_merge_cells',
+    'sheets_unmerge_cells',
+    'sheets_get_merged_cells',
+    'sheets_get_sheet_formatting',
+    'sheets_get_formatting_compact',
+    'sheets_add_conditional_formatting',
+    'sheets_get_conditional_formatting',
+    'sheets_get_data_validation',
+    'sheets_get_basic_filter',
+    'sheets_insert_link',
+    'sheets_insert_date',
+  ],
+  charts: ['sheets_create_chart', 'sheets_update_chart', 'sheets_delete_chart'],
+  tables: ['sheets_add_table', 'sheets_update_table', 'sheets_delete_table', 'sheets_get_tables'],
+  /** Whole-sheet reads and diffing — powerful, but the heaviest schemas. */
+  analysis: ['sheets_get_full_sheet_snapshot', 'sheets_compare_ranges'],
+};
+
+/**
+ * Tools that only read. Used both for `GSHEETS_READ_ONLY` and to emit
+ * `readOnlyHint` annotations so clients can skip confirmation prompts.
+ */
+export const READ_ONLY_TOOLS: ReadonlySet<string> = new Set([
+  'sheets_check_access',
+  'sheets_get_metadata',
+  'sheets_get_sheet_structure',
+  'sheets_get_sheet_dimensions',
+  'sheets_get_values',
+  'sheets_batch_get_values',
+  'sheets_get_border_map',
+  'sheets_get_merged_cells',
+  'sheets_get_sheet_formatting',
+  'sheets_get_formatting_compact',
+  'sheets_get_conditional_formatting',
+  'sheets_get_data_validation',
+  'sheets_get_basic_filter',
+  'sheets_get_tables',
+  'sheets_get_full_sheet_snapshot',
+  'sheets_compare_ranges',
+]);
+
+/**
+ * Tools that remove data outright, as opposed to overwriting it. Surfaced as
+ * `destructiveHint` so a client can warn before running them.
+ */
+const DESTRUCTIVE_TOOLS: ReadonlySet<string> = new Set([
+  'sheets_clear_values',
+  'sheets_delete_sheet',
+  'sheets_batch_delete_sheets',
+  'sheets_delete_rows',
+  'sheets_delete_columns',
+  'sheets_delete_chart',
+  'sheets_delete_table',
+  'sheets_unmerge_cells',
+]);
+
+export interface ToolsetConfig {
+  /** Toolsets that were requested, after defaulting and adding `core`. */
+  enabled: ToolsetName[];
+  readOnly: boolean;
+  /** Tool names the server should expose and accept calls for. */
+  allowed: ReadonlySet<string>;
+}
+
+export class ToolsetConfigError extends Error {}
+
+function parseList(raw: string): string[] {
+  return raw
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+/**
+ * Resolve the active toolsets from the environment.
+ *
+ * - Unset, empty, or `all` → every toolset (the pre-existing behaviour).
+ * - `core` is always added: without it the server cannot read a cell, and a
+ *   config like `GSHEETS_TOOLSETS=charts` is far more likely to mean "charts
+ *   as well" than "charts and nothing else".
+ * - An unknown name throws rather than being skipped — a typo that silently
+ *   drops half the tools is much harder to debug than a startup failure.
+ */
+export function resolveToolsets(env: NodeJS.ProcessEnv = process.env): ToolsetConfig {
+  const raw = env.GSHEETS_TOOLSETS?.trim();
+  const readOnly = env.GSHEETS_READ_ONLY?.trim().toLowerCase() === 'true';
+
+  let enabled: ToolsetName[];
+  if (!raw || raw.toLowerCase() === 'all') {
+    enabled = [...TOOLSET_NAMES];
+  } else {
+    const requested = parseList(raw);
+    const unknown = requested.filter((n) => !TOOLSET_NAMES.includes(n as ToolsetName));
+    if (unknown.length > 0) {
+      throw new ToolsetConfigError(
+        `Unknown toolset${unknown.length > 1 ? 's' : ''}: ${unknown.join(', ')}. ` +
+          `Valid toolsets: ${TOOLSET_NAMES.join(', ')}, all.`
+      );
+    }
+    const set = new Set<ToolsetName>(requested as ToolsetName[]);
+    set.add('core');
+    enabled = TOOLSET_NAMES.filter((n) => set.has(n));
+  }
+
+  const allowed = new Set<string>();
+  for (const name of enabled) {
+    for (const tool of TOOLSETS[name]) {
+      if (readOnly && !READ_ONLY_TOOLS.has(tool)) {
+        continue;
+      }
+      allowed.add(tool);
+    }
+  }
+
+  return { enabled, readOnly, allowed };
+}
+
+export interface ToolAnnotations {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+}
+
+/**
+ * MCP tool annotations derived from the read-only / destructive classification.
+ *
+ * Only hints that differ from the spec defaults are emitted. Annotations ride
+ * along in every `tools/list`, and spelling out `openWorldHint: true` on all
+ * 44 tools costs real context to say nothing. Spec defaults are
+ * `readOnlyHint: false`, `destructiveHint: true`, `idempotentHint: false`,
+ * `openWorldHint: true` — the last is correct for every tool here, since they
+ * all talk to the Google Sheets API.
+ */
+export function annotationsFor(toolName: string): ToolAnnotations {
+  if (READ_ONLY_TOOLS.has(toolName)) {
+    // destructiveHint is only meaningful for writes, so it is left off.
+    return { readOnlyHint: true, idempotentHint: true };
+  }
+
+  const annotations: ToolAnnotations = {};
+  // Default is destructive; only the reassuring case is worth stating.
+  if (!DESTRUCTIVE_TOOLS.has(toolName)) {
+    annotations.destructiveHint = false;
+  }
+  // Reads and full-range writes land on the same result when repeated;
+  // appends do not.
+  if (toolName !== 'sheets_append_values') {
+    annotations.idempotentHint = true;
+  }
+  return annotations;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,12 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 
 import { validateAuth } from './utils/google-auth.js';
+import {
+  resolveToolsets,
+  annotationsFor,
+  ToolsetConfigError,
+  TOOLSETS,
+} from './config/toolsets.js';
 
 // Import all tools
 import * as tools from './tools/index.js';
@@ -156,6 +162,31 @@ async function main() {
     process.exit(1);
   }
 
+  // Resolve which tools this process exposes. Fails fast on a bad toolset
+  // name rather than silently serving a smaller set than the user expects.
+  let toolsetConfig;
+  try {
+    toolsetConfig = resolveToolsets();
+  } catch (error) {
+    if (error instanceof ToolsetConfigError) {
+      console.error(`Configuration Error: ${error.message}`);
+      process.exit(1);
+    }
+    throw error;
+  }
+
+  const { enabled, readOnly, allowed } = toolsetConfig;
+  const exposedTools = allTools
+    .filter((tool) => allowed.has(tool.name))
+    .map((tool) => ({ ...tool, annotations: annotationsFor(tool.name) }));
+
+  if (enabled.length < Object.keys(TOOLSETS).length || readOnly) {
+    console.error(
+      `Toolsets: ${enabled.join(', ')}${readOnly ? ' (read-only)' : ''} — ` +
+        `${exposedTools.length}/${allTools.length} tools`
+    );
+  }
+
   const server = new Server(
     {
       name: 'spreadsheet',
@@ -173,13 +204,24 @@ async function main() {
   // List available tools
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     return {
-      tools: allTools,
+      tools: exposedTools,
     };
   });
 
   // Handle tool execution
   server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest) => {
     const { name, arguments: args } = request.params;
+
+    // Enforce the filter on the call path too. Hiding a tool from tools/list
+    // is a context optimisation, not a guarantee — read-only mode in
+    // particular has to hold even if a client calls a write tool by name.
+    if (!allowed.has(name)) {
+      throw new Error(
+        toolHandlers.has(name)
+          ? `Tool ${name} is disabled by the current GSHEETS_TOOLSETS/GSHEETS_READ_ONLY configuration`
+          : `Unknown tool: ${name}`
+      );
+    }
 
     const handler = toolHandlers.get(name);
     if (!handler) {

--- a/tests/unit/config/toolsets.test.ts
+++ b/tests/unit/config/toolsets.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  TOOLSETS,
+  TOOLSET_NAMES,
+  READ_ONLY_TOOLS,
+  resolveToolsets,
+  annotationsFor,
+  ToolsetConfigError,
+} from '../../../src/config/toolsets.js';
+import * as tools from '../../../src/tools/index.js';
+
+/** Every tool the server actually registers, read straight from the barrel. */
+const REGISTERED_TOOL_NAMES: string[] = Object.values(tools)
+  .filter(
+    (v): v is { name: string } =>
+      typeof v === 'object' && v !== null && typeof (v as { name?: unknown }).name === 'string'
+  )
+  .map((t) => t.name)
+  .filter((n) => n.startsWith('sheets_'));
+
+const ALL_GROUPED = Object.values(TOOLSETS).flat();
+
+describe('toolset definitions', () => {
+  it('covers every registered tool exactly once', () => {
+    // The guard that matters: add a tool and forget to file it, and this fails
+    // rather than the tool silently vanishing from every non-default config.
+    const grouped = new Set(ALL_GROUPED);
+    const registered = new Set(REGISTERED_TOOL_NAMES);
+
+    expect([...registered].filter((n) => !grouped.has(n))).toEqual([]);
+    expect([...grouped].filter((n) => !registered.has(n))).toEqual([]);
+    expect(ALL_GROUPED.length).toBe(new Set(ALL_GROUPED).size);
+  });
+
+  it('classifies only registered tools as read-only', () => {
+    const registered = new Set(REGISTERED_TOOL_NAMES);
+    expect([...READ_ONLY_TOOLS].filter((n) => !registered.has(n))).toEqual([]);
+  });
+
+  it('keeps core self-sufficient for reading and writing values', () => {
+    for (const tool of [
+      'sheets_get_values',
+      'sheets_update_values',
+      'sheets_get_metadata',
+      'sheets_check_access',
+    ]) {
+      expect(TOOLSETS.core).toContain(tool);
+    }
+  });
+});
+
+describe('resolveToolsets', () => {
+  it('enables everything when unset', () => {
+    const { enabled, readOnly, allowed } = resolveToolsets({});
+    expect(enabled).toEqual([...TOOLSET_NAMES]);
+    expect(readOnly).toBe(false);
+    expect(allowed.size).toBe(REGISTERED_TOOL_NAMES.length);
+  });
+
+  it('enables everything for "all"', () => {
+    expect(resolveToolsets({ GSHEETS_TOOLSETS: 'all' }).enabled).toEqual([...TOOLSET_NAMES]);
+  });
+
+  it('enables everything for an empty or whitespace value', () => {
+    expect(resolveToolsets({ GSHEETS_TOOLSETS: '' }).enabled).toEqual([...TOOLSET_NAMES]);
+    expect(resolveToolsets({ GSHEETS_TOOLSETS: '   ' }).enabled).toEqual([...TOOLSET_NAMES]);
+  });
+
+  it('restricts to the named toolsets', () => {
+    const { enabled, allowed } = resolveToolsets({ GSHEETS_TOOLSETS: 'core,charts' });
+    expect(enabled).toEqual(['core', 'charts']);
+    expect(allowed.has('sheets_create_chart')).toBe(true);
+    expect(allowed.has('sheets_get_values')).toBe(true);
+    expect(allowed.has('sheets_format_cells')).toBe(false);
+  });
+
+  it('always adds core, even when not requested', () => {
+    const { enabled, allowed } = resolveToolsets({ GSHEETS_TOOLSETS: 'charts' });
+    expect(enabled).toEqual(['core', 'charts']);
+    expect(allowed.has('sheets_get_values')).toBe(true);
+  });
+
+  it('is tolerant of spacing and case', () => {
+    expect(resolveToolsets({ GSHEETS_TOOLSETS: ' Charts , TABLES ' }).enabled).toEqual([
+      'core',
+      'charts',
+      'tables',
+    ]);
+  });
+
+  it('returns toolsets in declaration order regardless of input order', () => {
+    expect(resolveToolsets({ GSHEETS_TOOLSETS: 'analysis,charts,core' }).enabled).toEqual([
+      'core',
+      'charts',
+      'analysis',
+    ]);
+  });
+
+  it('ignores duplicates', () => {
+    expect(resolveToolsets({ GSHEETS_TOOLSETS: 'charts,charts' }).enabled).toEqual([
+      'core',
+      'charts',
+    ]);
+  });
+
+  it('throws on an unknown toolset rather than silently dropping it', () => {
+    expect(() => resolveToolsets({ GSHEETS_TOOLSETS: 'core,chart' })).toThrow(ToolsetConfigError);
+    expect(() => resolveToolsets({ GSHEETS_TOOLSETS: 'core,chart' })).toThrow(
+      /Unknown toolset: chart\./
+    );
+  });
+
+  it('lists every unknown name and the valid ones', () => {
+    try {
+      resolveToolsets({ GSHEETS_TOOLSETS: 'nope,alsonope' });
+      expect.unreachable('should have thrown');
+    } catch (error) {
+      const message = (error as Error).message;
+      expect(message).toContain('Unknown toolsets: nope, alsonope');
+      expect(message).toContain('core, sheets, formatting, charts, tables, analysis, all');
+    }
+  });
+});
+
+describe('GSHEETS_READ_ONLY', () => {
+  it('drops every writing tool', () => {
+    const { readOnly, allowed } = resolveToolsets({ GSHEETS_READ_ONLY: 'true' });
+    expect(readOnly).toBe(true);
+    expect(allowed.size).toBe(READ_ONLY_TOOLS.size);
+    for (const name of allowed) expect(READ_ONLY_TOOLS.has(name)).toBe(true);
+  });
+
+  it('intersects with the toolset filter', () => {
+    const { allowed } = resolveToolsets({
+      GSHEETS_TOOLSETS: 'core,charts',
+      GSHEETS_READ_ONLY: 'true',
+    });
+    expect(allowed.has('sheets_get_values')).toBe(true);
+    expect(allowed.has('sheets_update_values')).toBe(false);
+    // charts has no read-only member, so it contributes nothing here
+    expect(allowed.has('sheets_create_chart')).toBe(false);
+  });
+
+  it('is off unless the value is exactly true', () => {
+    for (const value of ['false', '1', 'yes', '']) {
+      expect(resolveToolsets({ GSHEETS_READ_ONLY: value }).readOnly).toBe(false);
+    }
+    expect(resolveToolsets({ GSHEETS_READ_ONLY: 'TRUE' }).readOnly).toBe(true);
+  });
+});
+
+describe('annotationsFor', () => {
+  it('marks reads read-only and idempotent', () => {
+    expect(annotationsFor('sheets_get_values')).toEqual({
+      readOnlyHint: true,
+      idempotentHint: true,
+    });
+  });
+
+  it('leaves deletes at the destructive default', () => {
+    // destructiveHint defaults to true, so a delete needs no annotation for it
+    const annotations = annotationsFor('sheets_delete_sheet');
+    expect(annotations.destructiveHint).toBeUndefined();
+    expect(annotations.readOnlyHint).toBeUndefined();
+  });
+
+  it('marks non-destructive writes explicitly', () => {
+    expect(annotationsFor('sheets_update_values')).toEqual({
+      destructiveHint: false,
+      idempotentHint: true,
+    });
+  });
+
+  it('omits idempotentHint for append', () => {
+    expect(annotationsFor('sheets_append_values').idempotentHint).toBeUndefined();
+    expect(annotationsFor('sheets_update_values').idempotentHint).toBe(true);
+  });
+
+  it('never emits a hint that just restates a spec default', () => {
+    for (const name of REGISTERED_TOOL_NAMES) {
+      const a = annotationsFor(name) as Record<string, unknown>;
+      expect(a.readOnlyHint).not.toBe(false);
+      expect(a.destructiveHint).not.toBe(true);
+      expect(a.idempotentHint).not.toBe(false);
+      expect(a).not.toHaveProperty('openWorldHint');
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,12 @@ export default defineConfig({
       provider: 'v8',
       // lcov is what Codecov consumes — without it CI has nothing to upload.
       reporter: ['text', 'json', 'html', 'lcov'],
+      // Measure every source file, not just the ones some test happened to
+      // import. Without this the denominator tracks the import graph: the
+      // suite reported 95% while a third of src/ was never looked at, and the
+      // number moved whenever a test added an import.
+      all: true,
+      include: ['src/**/*.ts'],
       exclude: [
         'node_modules/**',
         'dist/**',
@@ -19,11 +25,15 @@ export default defineConfig({
         'tests/**',
         'scripts/**',
       ],
+      // Set just under the current real numbers so they act as a ratchet:
+      // coverage cannot slip, and each improvement should raise the floor.
+      // Target is 80 across the board once the untested tool handlers are
+      // covered.
       thresholds: {
-        branches: 80,
-        functions: 80,
-        lines: 80,
-        statements: 80,
+        branches: 64,
+        functions: 76,
+        lines: 67,
+        statements: 67,
       },
     },
     include: ['tests/**/*.test.ts'],


### PR DESCRIPTION
All 44 tools serialise to ~39 KB of `tools/list` — about **9,900 tokens spent in every session** before the model does anything. Most workflows need a fraction of that.

## Toolsets

`GSHEETS_TOOLSETS` selects from six groups:

| Toolset | Tools | Covers |
|---|---|---|
| `core` | 11 | Read/write values, metadata, sheet structure, create spreadsheet |
| `sheets` | 9 | Sheet lifecycle, rows and columns |
| `formatting` | 15 | Colours, borders, merges, conditional rules, links, dates |
| `charts` | 3 | Create, update, delete charts |
| `tables` | 4 | Native tables |
| `analysis` | 2 | Full-sheet snapshot, range comparison |

Measured against a running server, not estimated:

| Configuration | Tools | ≈ Tokens |
|---|---|---|
| _unset_ (default) | 44 | 9,875 |
| `core` | 11 | 1,986 |
| `core,sheets` | 20 | 3,548 |
| `charts` (core auto-added) | 14 | 3,328 |
| `GSHEETS_READ_ONLY=true` | 16 | 3,599 |
| `core` + read-only | 6 | 912 |

## Design choices

- **The default is unchanged.** Unset means every tool, so no existing config breaks. With ~10k downloads/month, opting everyone into a smaller tool list would be the wrong trade.
- **`core` is always included.** `GSHEETS_TOOLSETS=charts` means "charts as well", not "charts only" — without core the server cannot read a cell.
- **An unknown name is a startup error** listing the valid ones. A typo that silently halves the tool list is much harder to debug than a refusal to start.
- **The filter is enforced on `tools/call`,** not just `tools/list`. Hiding a tool is a context optimisation; read-only mode has to hold even when a client names a hidden write tool directly.

Verified by driving the built server:

```
GSHEETS_READ_ONLY=true
  sheets_update_values  -> ERR: Tool sheets_update_values is disabled by the current ... configuration
  sheets_delete_sheet   -> ERR: Tool sheets_delete_sheet is disabled by the current ... configuration
  sheets_get_values     -> passes the filter through to the handler
  sheets_bogus_tool     -> ERR: Unknown tool: sheets_bogus_tool
```

## Annotations

Tools now carry MCP annotations, derived from the same read-only/destructive classification that backs `GSHEETS_READ_ONLY`. Only hints that differ from spec defaults are emitted — writing `openWorldHint: true` on 44 tools costs context to say nothing.

This still adds ~600 tokens to the default config (9,262 -> 9,875). That is the honest price of letting clients skip confirmation prompts on the 16 read tools and warn before destructive ones. Anyone who cares about context uses a toolset, which more than pays it back.

## Correction: coverage was never 95%

Worth flagging, because [#129](https://github.com/freema/mcp-gsheets/pull/129) reported 95.05% and that figure was wrong.

v8 only counts files that some test imported. The new toolsets test imports the tools barrel to check exhaustiveness, which pulled 519 previously invisible statements into the denominator and dropped the number to 72.9%. Enabling `coverage.all` with an explicit `src/**/*.ts` include revealed 30 more files that no test had ever loaded — **lcov goes from 34 files to 64**.

The real figure:

```
Statements   : 67.90% ( 1352/1991 )
Branches     : 64.93% ( 1074/1654 )
Functions    : 76.30% (  190/249  )
Lines        : 67.45% ( 1314/1948 )
```

So the badge will drop from 95% to ~68%. That is not a regression — it is the first honest measurement. Thresholds are set just under the true numbers so they ratchet rather than flatter; 80 across the board is the target once the untested tool handlers are covered.

## Tests

513 pass, 21 new. Includes a test that fails if a tool is added without being filed into a toolset, so the groups cannot silently drift from the registry.