### PR TITLE
chore: release 1.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-gsheets",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-gsheets",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-gsheets",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "mcpName": "io.github.freema/mcp-gsheets",
   "description": "Model Context Protocol (MCP) server for Google Sheets API integration",
   "author": "freema",

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/freema/mcp-gsheets",
     "source": "github"
   },
-  "version": "1.10.0",
+  "version": "1.10.1",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-gsheets",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Patch release covering the dependency updates merged since v1.10.0 (#132-#136).

- zod 3.25.76 -> 4.4.3 (major)
- @modelcontextprotocol/sdk 1.29.0 -> 1.30.0
- @vitest/coverage-v8 and vitest 4.1.4 -> 4.1.10
- tsx 4.21.0 -> 4.23.1

zod and the MCP SDK are bundled into `dist` via tsup `noExternal`, so both ship in the published package. Each bump was merged with the full CI matrix green (lint, format, typecheck, tests with coverage, build on Node 20 and 22).

Bumps package.json, package-lock.json and server.json to 1.10.1.