### PR TITLE
fix: publish JSON Schema instead of Zod internals in tool input schemas

### DIFF
--- a/src/tools/conditional-formatting.ts
+++ b/src/tools/conditional-formatting.ts
@@ -7,6 +7,7 @@ import { formatToolResponse } from '../utils/formatters.js';
 import { AddConditionalFormattingInput, ToolResponse } from '../types/tools.js';
 import { parseRange, getSheetId, extractSheetName } from '../utils/range-helpers.js';
 import { parseJsonInput } from '../utils/json-parser.js';
+import { toInputSchema } from '../utils/tool-schema.js';
 
 // Schema definitions
 const colorSchema = z.object({
@@ -115,11 +116,7 @@ const addConditionalFormattingInputSchema = z.object({
 export const addConditionalFormattingTool: Tool = {
   name: 'sheets_add_conditional_formatting',
   description: 'Add conditional formatting rules to a Google Sheet',
-  inputSchema: {
-    type: 'object',
-    properties: addConditionalFormattingInputSchema.shape,
-    required: ['spreadsheetId', 'rules'],
-  },
+  inputSchema: toInputSchema(addConditionalFormattingInputSchema),
 };
 
 export async function addConditionalFormattingHandler(input: any): Promise<ToolResponse> {

--- a/src/tools/format-cells.ts
+++ b/src/tools/format-cells.ts
@@ -7,6 +7,7 @@ import { formatToolResponse } from '../utils/formatters.js';
 import { FormatCellsInput, ToolResponse } from '../types/tools.js';
 import { parseRange, getSheetId, extractSheetName } from '../utils/range-helpers.js';
 import { parseJsonInput } from '../utils/json-parser.js';
+import { toInputSchema } from '../utils/tool-schema.js';
 
 // Schema definitions
 const colorSchema = z
@@ -72,11 +73,7 @@ const formatCellsInputSchema = z.object({
 export const formatCellsTool: Tool = {
   name: 'sheets_format_cells',
   description: 'Format cells in a Google Sheet (colors, fonts, alignment, number formats)',
-  inputSchema: {
-    type: 'object',
-    properties: formatCellsInputSchema.shape,
-    required: ['spreadsheetId', 'range', 'format'],
-  },
+  inputSchema: toInputSchema(formatCellsInputSchema),
 };
 
 export async function formatCellsHandler(input: any): Promise<ToolResponse> {

--- a/src/tools/merge-cells.ts
+++ b/src/tools/merge-cells.ts
@@ -5,6 +5,7 @@ import { handleError } from '../utils/error-handler.js';
 import { formatToolResponse } from '../utils/formatters.js';
 import { MergeCellsInput, UnmergeCellsInput, ToolResponse } from '../types/tools.js';
 import { parseRange, getSheetId, extractSheetName } from '../utils/range-helpers.js';
+import { toInputSchema } from '../utils/tool-schema.js';
 
 // Schema definitions
 const mergeCellsInputSchema = z.object({
@@ -21,21 +22,13 @@ const unmergeCellsInputSchema = z.object({
 export const mergeCellsTool: Tool = {
   name: 'sheets_merge_cells',
   description: 'Merge cells in a Google Sheet',
-  inputSchema: {
-    type: 'object',
-    properties: mergeCellsInputSchema.shape,
-    required: ['spreadsheetId', 'range', 'mergeType'],
-  },
+  inputSchema: toInputSchema(mergeCellsInputSchema),
 };
 
 export const unmergeCellsTool: Tool = {
   name: 'sheets_unmerge_cells',
   description: 'Unmerge cells in a Google Sheet',
-  inputSchema: {
-    type: 'object',
-    properties: unmergeCellsInputSchema.shape,
-    required: ['spreadsheetId', 'range'],
-  },
+  inputSchema: toInputSchema(unmergeCellsInputSchema),
 };
 
 export async function mergeCellsHandler(input: any): Promise<ToolResponse> {

--- a/src/tools/update-borders.ts
+++ b/src/tools/update-borders.ts
@@ -7,6 +7,7 @@ import { formatToolResponse } from '../utils/formatters.js';
 import { UpdateBordersInput, ToolResponse } from '../types/tools.js';
 import { parseRange, getSheetId, extractSheetName } from '../utils/range-helpers.js';
 import { parseJsonInput } from '../utils/json-parser.js';
+import { toInputSchema } from '../utils/tool-schema.js';
 
 // Schema definitions
 const colorSchema = z
@@ -44,11 +45,7 @@ const updateBordersInputSchema = z.object({
 export const updateBordersTool: Tool = {
   name: 'sheets_update_borders',
   description: 'Update borders of cells in a Google Sheet',
-  inputSchema: {
-    type: 'object',
-    properties: updateBordersInputSchema.shape,
-    required: ['spreadsheetId', 'range', 'borders'],
-  },
+  inputSchema: toInputSchema(updateBordersInputSchema),
 };
 
 export async function updateBordersHandler(input: any): Promise<ToolResponse> {

--- a/src/utils/tool-schema.ts
+++ b/src/utils/tool-schema.ts
@@ -1,0 +1,18 @@
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+
+/**
+ * Converts a Zod object schema into the JSON Schema that MCP `Tool.inputSchema` expects.
+ *
+ * Assigning a Zod schema's `.shape` directly to `inputSchema.properties` publishes Zod
+ * internals instead of JSON Schema, so clients receive a tool definition they cannot
+ * validate against JSON Schema draft 2020-12.
+ *
+ * @param schema - The Zod object schema describing the tool input
+ * @returns The tool input as JSON Schema
+ */
+export function toInputSchema(schema: z.ZodObject<z.ZodRawShape>): Tool['inputSchema'] {
+  const jsonSchema = z.toJSONSchema(schema, { io: 'input' });
+  delete jsonSchema.$schema;
+  return jsonSchema as Tool['inputSchema'];
+}

--- a/tests/unit/tools/tool-schemas.test.ts
+++ b/tests/unit/tools/tool-schemas.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+import * as tools from '../../../src/tools/index.js';
+
+/**
+ * Tool definitions are published verbatim over `tools/list`, so an input schema that is
+ * not valid JSON Schema is rejected by the client rather than by this server. Clients
+ * reject the whole request, which takes every tool down at once, so these checks cover
+ * all exported tools rather than a hand-picked sample.
+ *
+ * Each schema is serialized first, because that is what a client actually receives.
+ */
+
+const JSON_SCHEMA_TYPES = ['object', 'array', 'string', 'number', 'integer', 'boolean', 'null'];
+
+// Keywords JSON Schema defines as a non-negative integer.
+const INTEGER_KEYWORDS = [
+  'minLength',
+  'maxLength',
+  'minItems',
+  'maxItems',
+  'minProperties',
+  'maxProperties',
+];
+
+// Keys that only appear when a Zod schema is published instead of being converted.
+const ZOD_INTERNAL_KEYS = ['_def', 'def', '_zod', '~standard'];
+
+const SCHEMA_FORMS = ['type', 'enum', 'const', 'anyOf', 'oneOf', 'allOf', '$ref'];
+
+// Keywords whose value is itself a schema.
+const SCHEMA_VALUED = ['items', 'contains', 'not', 'if', 'then', 'else', 'propertyNames'];
+// Keywords holding a map of schemas.
+const SCHEMA_MAPS = ['properties', 'patternProperties', '$defs', 'definitions'];
+// Keywords holding a list of schemas.
+const SCHEMA_LISTS = ['anyOf', 'oneOf', 'allOf', 'prefixItems'];
+
+type JsonObject = Record<string, unknown>;
+
+const isObject = (value: unknown): value is JsonObject =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const toolEntries: [string, Tool][] = Object.values(tools)
+  .filter(
+    (value): value is Tool =>
+      isObject(value) && typeof value.name === 'string' && isObject(value.inputSchema)
+  )
+  .map((tool) => [tool.name, tool]);
+
+/** Visits every node that sits in a JSON Schema position, skipping property-name maps. */
+function eachSchema(root: unknown, visit: (schema: JsonObject, path: string) => void) {
+  const walk = (node: unknown, path: string) => {
+    if (!isObject(node)) return;
+    visit(node, path);
+
+    for (const keyword of SCHEMA_VALUED) {
+      if (keyword in node) walk(node[keyword], `${path}.${keyword}`);
+    }
+    for (const keyword of SCHEMA_MAPS) {
+      const map = node[keyword];
+      if (!isObject(map)) continue;
+      for (const [key, child] of Object.entries(map)) walk(child, `${path}.${keyword}.${key}`);
+    }
+    for (const keyword of SCHEMA_LISTS) {
+      const list = node[keyword];
+      if (!Array.isArray(list)) continue;
+      list.forEach((child, i) => walk(child, `${path}.${keyword}[${i}]`));
+    }
+    if (isObject(node.additionalProperties)) {
+      walk(node.additionalProperties, `${path}.additionalProperties`);
+    }
+  };
+  walk(root, 'inputSchema');
+}
+
+/** The schema exactly as a client receives it. */
+const published = (tool: Tool): JsonObject => JSON.parse(JSON.stringify(tool.inputSchema));
+
+describe('tool input schemas', () => {
+  it('discovers the exported tools', () => {
+    expect(toolEntries.length).toBeGreaterThan(0);
+  });
+
+  it.each(toolEntries)('%s declares an object schema', (_name, tool) => {
+    expect(published(tool).type).toBe('object');
+  });
+
+  it.each(toolEntries)('%s publishes no Zod internals', (_name, tool) => {
+    eachSchema(published(tool), (schema, path) => {
+      for (const key of ZOD_INTERNAL_KEYS) {
+        expect(
+          key in schema,
+          `${path} leaks the Zod internal key "${key}" — convert the schema with toInputSchema()`
+        ).toBe(false);
+      }
+    });
+  });
+
+  it.each(toolEntries)('%s uses well-typed JSON Schema keywords', (_name, tool) => {
+    eachSchema(published(tool), (schema, path) => {
+      if ('type' in schema) {
+        const declared = Array.isArray(schema.type) ? schema.type : [schema.type];
+        for (const entry of declared) {
+          expect(JSON_SCHEMA_TYPES, `${path}.type is ${JSON.stringify(entry)}`).toContain(entry);
+        }
+      }
+      if ('enum' in schema) {
+        expect(Array.isArray(schema.enum), `${path}.enum must be an array`).toBe(true);
+      }
+      if ('format' in schema) {
+        expect(typeof schema.format, `${path}.format must be a string`).toBe('string');
+      }
+      for (const keyword of INTEGER_KEYWORDS) {
+        if (keyword in schema) {
+          expect(
+            Number.isInteger(schema[keyword]),
+            `${path}.${keyword} must be an integer, got ${JSON.stringify(schema[keyword])}`
+          ).toBe(true);
+        }
+      }
+    });
+  });
+
+  it.each(toolEntries)('%s gives every property a schema', (_name, tool) => {
+    eachSchema(published(tool), (schema, path) => {
+      if (!isObject(schema.properties)) return;
+      for (const [property, child] of Object.entries(schema.properties)) {
+        expect(isObject(child), `${path}.properties.${property} must be an object`).toBe(true);
+        const keys = Object.keys(child as JsonObject);
+        expect(
+          keys.some((key) => SCHEMA_FORMS.includes(key)),
+          `${path}.properties.${property} declares no JSON Schema form, only: ${keys.join(', ')}`
+        ).toBe(true);
+      }
+    });
+  });
+
+  it.each(toolEntries)('%s only requires properties it declares', (_name, tool) => {
+    eachSchema(published(tool), (schema, path) => {
+      if (!Array.isArray(schema.required) || !isObject(schema.properties)) return;
+      const declared = Object.keys(schema.properties);
+      for (const required of schema.required) {
+        expect(declared, `${path}.required lists "${String(required)}"`).toContain(required);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Fixes #138.

## What was wrong

Five tools assigned a Zod schema's `.shape` directly to `inputSchema.properties`:

```ts
inputSchema: {
  type: 'object',
  properties: mergeCellsInputSchema.shape,   // Zod type instances, not JSON Schema
  required: ['spreadsheetId', 'range', 'mergeType'],
},
```

`.shape` is a map of Zod types. What reaches the client is whatever those serialize to, which changed under #132 (`zod` 3.25.76 to 4.4.3, shipped in 1.10.1):

| | serialized entry | effect |
|---|---|---|
| zod 3 | `{"_def": {...}, "~standard": {...}} `| unknown keywords, ignored by validators. Loaded fine, but the tools shipped with no parameter types at all |
| zod 4 | `{"type":"string","format":null,"minLength":null,"maxLength":null}` | known keywords with wrong value types. Invalid JSON Schema |

Clients that validate tool definitions against draft 2020-12 reject the whole request rather than the single tool, so on 1.10.1 the server takes every tool down as soon as it loads.

## The change

`src/utils/tool-schema.ts` adds a `toInputSchema()` helper over zod 4's built-in `z.toJSONSchema()`, so no new dependency. The five call sites now use it, and the hand-written `required` lists are dropped because the conversion derives the same ones from the Zod schema (verified tool by tool).

Beyond fixing the crash, these five tools now describe their parameters properly for the first time. `sheets_merge_cells` before and after:

```json
// before, on 1.10.1
"mergeType": {
  "def": { "type": "enum", "entries": {"MERGE_ALL": "MERGE_ALL", "...": "..."} },
  "type": "enum",
  "enum": { "MERGE_ALL": "MERGE_ALL", "MERGE_COLUMNS": "MERGE_COLUMNS", "MERGE_ROWS": "MERGE_ROWS" },
  "options": ["MERGE_ALL", "MERGE_COLUMNS", "MERGE_ROWS"]
}

// after
"mergeType": { "type": "string", "enum": ["MERGE_ALL", "MERGE_COLUMNS", "MERGE_ROWS"] }
```

The nested schemas benefit most: `sheets_format_cells`, `sheets_update_borders` and `sheets_add_conditional_formatting` now publish their full object trees, enums and `minimum`/`maximum` bounds instead of an opaque blob.

The helper strips the `$schema` key that `z.toJSONSchema()` adds, to keep the output consistent with the 39 hand-written schemas.

## The test

`tests/unit/tools/tool-schemas.test.ts` walks the **published** schema of every exported tool, meaning `JSON.parse(JSON.stringify(inputSchema))`, since that is what a client receives. It asserts no Zod internals leak, that JSON Schema keywords are well typed, that every declared property has a schema form, and that `required` only lists declared properties.

Serializing first matters: `z.toJSONSchema()` attaches a non-enumerable `~standard` property that never crosses the wire, so checking the live object would report a false positive.

The traversal only descends into real schema positions (`properties`, `items`, `$defs`, `anyOf` and friends), so a tool with a property genuinely named `type` or `format`, like `sheets_create_chart`, is not mistaken for a mistyped keyword.

Reverting `src/` and keeping the test produces 10 failures, exactly the 5 affected tools against 2 checks each, and no false positives on the other 39.

## Verification

- `npm run check:all` passes: typecheck, lint, format, 734 tests across 33 files, build.
- The previous 513 tests still pass untouched.
- Built `dist/index.js`, drove it over stdio with a real `initialize` + `tools/list`, and ran `jsonschema.Draft202012Validator.check_schema()` over all 44 tools: 0 invalid, against 5 invalid on unpatched 1.10.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
