### PR TITLE
chore(deps): stop Dependabot raising the TypeScript major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,12 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "deps:"
+    ignore:
+      # TypeScript 7 is the current `latest`, but every released
+      # typescript-eslint — including the canary — peers on
+      # `typescript: >=4.8.4 <6.1.0`, so a major bump makes `npm ci` fail
+      # with ERESOLVE. Remove this entry once typescript-eslint ships
+      # TypeScript 7 support.
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
Closes the loop on #141.

`typescript@7.0.2` is the current `latest` on npm, but no released `typescript-eslint` accepts it — 8.69.0 and the `8.69.1-alpha.0` canary both declare `peer typescript: ">=4.8.4 <6.1.0"`. The bump therefore dies in `npm ci` with `ERESOLVE`, before lint or tests run.

Without an ignore rule Dependabot re-raises that same unmergeable PR on every TypeScript 7.x release. This adds one narrowly scoped entry:

- only `version-update:semver-major` for `typescript` is ignored — 5.x minor and patch updates keep flowing
- nothing else in the config changes

The comment in the file records why, so the entry can be dropped once typescript-eslint ships TypeScript 7 support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kMRiN2aK2zoJz4aYhuPrh